### PR TITLE
update for easybuild 3.5.1; fixes/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,27 +5,22 @@
 
 ##  As root:
 
-First create an empty image
+Build the image
 ```
-$> singularity create -s 4096 centos7.2-easybuild3.0.1
-```
-
-Now bootstrap it
-```
-$> singularity bootstrap centos7.2-easybuild3.0.1 centos-7.2-easybuild-3.0.1.bootstrap
+$> singularity build centos-7-easybuild-3.5.1 centos-7-easybuild-3.5.1.bootstrap
 ```
 
 ## As regular user:
 
-Once bootstrap is done open run the container as standard user (non root)
+Once build is done open run the container as standard user (non root)
 ```
-$> singularity shell --shell /bin/bash centos7.2-easybuild3.0.1
+$> singularity shell --shell /bin/bash centos-7-easybuild-3.5.1
 ```
 
 If you want write permissions in the container:
 ```
-$> chown yourusername centos7.2-easybuild3.0.1
-$> singularity shell --shell /bin/bash -w centos7.2-easybuild3.0.1
+$> chown yourusername centos-7-easybuild-3.5.1
+$> singularity shell --shell /bin/bash -w centos-7-easybuild-3.5.1
 ```
 
 Once inside the container

--- a/centos-7-easybuild-3.5.1.bootstrap
+++ b/centos-7-easybuild-3.5.1.bootstrap
@@ -16,11 +16,17 @@ Include: yum
     export EASYBUILD_VERSION="3.5.1"
     yum -y install gcc
     yum -y install gcc-c++
+    yum -y install glibc-static       # workaround for intel stack protector bug
+    yum -y install glibc.i686	      # workaround for OpenBLAS bug
     yum -y install make
+    yum -y install glib2-devel        # osbuilddepends for some module
+    yum -y install texlive            # osbuilddepends for some module
     yum -y install openssl-devel
     yum -y install libibverbs-devel
     yum -y install tar bzip2 gzip unzip
+    yum -y install tcsh
     yum -y install which
+    yum -y install wget
     yum -y install epel-release
     yum -y install python-pip
     yum -y install Lmod
@@ -29,4 +35,12 @@ Include: yum
     yum -y install patch
     yum -y install GitPython
     yum -y install file
+    yum -y install perl-Data-Dumper   # for build of autoconf-2.69
+    yum -y install perl-Thread-Queue  # for build of automake-1.15
+    yum -y install libX11-devel       # for Tk
+    yum -y install m4                 # missed 'nettle' dependency
+    yum -y install strace             # for debugging
+    yum -y install emacs-nox          # for debugging
+    pip install --upgrade pip
     pip install easybuild==$EASYBUILD_VERSION
+    pip install pycodestyle           # for eb --check-style


### PR DESCRIPTION
Switch to EasyBuild 3.5.1.  Add some missing rpm's that the current
easyconfigs assume will be present.  Also add a few that are handy for
development and debugging.

(Your configs are incredibly handy, BTW!)